### PR TITLE
Hw4: Memory paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+compile_commands.json
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/syspage.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -139,6 +140,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_pgtest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -353,6 +353,7 @@ typedef uint64 *pagetable_t; // 512 PTEs
 
 #define PGSIZE 4096 // bytes per page
 #define PGSHIFT 12  // bits of offset within a page
+#define PTECOUNT 512 // number of PTEs per page table
 
 #define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
 #define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
@@ -362,8 +363,11 @@ typedef uint64 *pagetable_t; // 512 PTEs
 #define PTE_W (1L << 2)
 #define PTE_X (1L << 3)
 #define PTE_U (1L << 4) // user can access
+#define PTE_G (1L << 5)
+#define PTE_A (1L << 6)
+#define PTE_D (1L << 7)
 
-// shift a physical address to the right place for a PTE.
+// shift a physical addresPGSIZE << (9 * level)s to the right place for a PTE.
 #define PA2PTE(pa) ((((uint64)pa) >> 12) << 10)
 
 #define PTE2PA(pte) (((pte) >> 10) << 12)
@@ -374,6 +378,7 @@ typedef uint64 *pagetable_t; // 512 PTEs
 #define PXMASK          0x1FF // 9 bits
 #define PXSHIFT(level)  (PGSHIFT+(9*(level)))
 #define PX(level, va) ((((uint64) (va)) >> PXSHIFT(level)) & PXMASK)
+#define PAGESIZE(level) (1 << PXSHIFT(level))
 
 // one beyond the highest possible virtual address.
 // MAXVA is actually one bit less than the max allowed by

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -354,7 +354,7 @@ typedef uint64 *pagetable_t; // 512 PTEs
 #define PGSIZE 4096 // bytes per page
 #define PGSHIFT 12  // bits of offset within a page
 #define PTECOUNT 512 // number of PTEs per page table
-#define PTESHIFT 9   // number of PTEs per page table
+#define PTESHIFT 9   // bits of PTE offset
 
 #define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
 #define PGROUNDUPLVL(level, sz) (((sz)+(PGSIZE << (level * PTESHIFT))-1) & ~((PGSIZE << (level * PTESHIFT))-1))

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -354,8 +354,10 @@ typedef uint64 *pagetable_t; // 512 PTEs
 #define PGSIZE 4096 // bytes per page
 #define PGSHIFT 12  // bits of offset within a page
 #define PTECOUNT 512 // number of PTEs per page table
+#define PTESHIFT 9   // number of PTEs per page table
 
 #define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
+#define PGROUNDUPLVL(level, sz) (((sz)+(PGSIZE << (level * PTESHIFT))-1) & ~((PGSIZE << (level * PTESHIFT))-1))
 #define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
 
 #define PTE_V (1L << 0) // valid

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,8 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_pagedump(void);
+extern uint64 sys_pagereset(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +128,8 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_pagedump]   sys_pagedump,
+[SYS_pagereset]  sys_pagereset,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,5 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_pagedump  22
+#define SYS_pagereset 23

--- a/kernel/syspage.c
+++ b/kernel/syspage.c
@@ -39,6 +39,7 @@ char *format_index(char *buffer, uint64 index) {
 
 void print_reqursive(pagetable_t pagetable, uint64 va, uint64 last_va,
                      int level, int flags_mask) {
+  last_va = PGROUNDUPLVL(level, last_va);
   pte_t *pte = pagetable + PX(level, va);
   for (; va < last_va && pte < pagetable + PTECOUNT; va += PAGESIZE(level), ++pte) {
     
@@ -100,6 +101,7 @@ uint64 sys_pagedump(void) {
 
 void reset_reqursive(pagetable_t pagetable, uint64 va, uint64 last_va,
                      int level, int flags_mask) {
+  last_va = PGROUNDUPLVL(level, last_va);
   pte_t *pte = pagetable + PX(level, va);
   for (; va < last_va && pte < pagetable + PTECOUNT; va += PAGESIZE(level), ++pte) {
     
@@ -136,11 +138,11 @@ uint64 sys_pagereset(void) {
   int flags_mask;
   argint(2, &flags_mask);
 
-  if (flags_mask == 1) {
+  if (flags_mask == DIRTY_PAGE) {
     flags_mask = PTE_D;
-  } else if (flags_mask == 2) {
+  } else if (flags_mask == ACCESSED_PAGE) {
     flags_mask = PTE_A;
-  } else if (flags_mask == 3) {
+  } else if (flags_mask == (DIRTY_PAGE | ACCESSED_PAGE)) {
     flags_mask = PTE_D | PTE_A;
   } else {
     return -1;

--- a/kernel/syspage.c
+++ b/kernel/syspage.c
@@ -1,0 +1,155 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "param.h"
+#include "spinlock.h"
+#include "proc.h"
+
+static const int MAX_LEVEL = 2;
+
+char *compute_flags(char *flags, pte_t *pte) {
+  flags[0] = (*pte & PTE_R) ? 'R' : '_';
+  flags[1] = (*pte & PTE_W) ? 'W' : '_';
+  flags[2] = (*pte & PTE_X) ? 'X' : '_';
+  flags[3] = (*pte & PTE_U) ? 'U' : '_';
+  flags[4] = (*pte & PTE_G) ? 'G' : '_';
+  flags[5] = (*pte & PTE_A) ? 'A' : '_';
+  flags[6] = (*pte & PTE_D) ? 'D' : '_';
+  flags[7] = '\0';
+  return flags;
+}
+
+char *format_index(char *buffer, uint64 index) {
+  buffer[0] = '0';
+  buffer[1] = 'x';
+
+  if ((buffer[4] = index % 16 + '0') > '9') {
+    buffer[4] += 'a' - '9' - 1;
+  };
+  index /= 16;
+  if ((buffer[3] = index % 16 + '0') > '9') {
+    buffer[3] += 'a' - '9' - 1;
+  };
+  index /= 16;
+  if ((buffer[2] = index % 16 + '0') > '9') {
+    buffer[2] += 'a' - '9' - 1;
+  };
+  return buffer;
+}
+
+void print_reqursive(pagetable_t pagetable, uint64 va, uint64 last_va,
+                     int level, int flags_mask) {
+  pte_t *pte = pagetable + PX(level, va);
+  for (; va < last_va && pte < pagetable + PTECOUNT; va += PAGESIZE(level), ++pte) {
+    
+    if (!(*pte & PTE_V)) {
+      continue;
+    }
+
+    if (level == 0 && flags_mask != 0 && (*pte & (uint64)flags_mask) == 0) {
+      continue;
+    }
+
+    for (int i = level; i < MAX_LEVEL; ++i) { printf("      "); }
+    printf("%s -> %p %s\n", format_index("0x000", PX(level, va)),
+           (void *)PTE2PA(*pte), compute_flags("rwxugad", pte));
+
+    if (level > 0) {
+      print_reqursive((pagetable_t)PTE2PA(*pte), va, last_va, level - 1,
+                      flags_mask);
+    }
+  }
+}
+
+uint64 sys_pagedump(void) {
+  uint64 buf;
+  argaddr(0, &buf);
+  uint64 len;
+  argaddr(1, &len);
+
+  if (buf == 0 || len == 0) {
+    buf = 0;
+    len = MAXVA;
+  }
+
+  if (buf + len > MAXVA) {
+    return -1;
+  }
+
+  int flags_mask;
+  argint(2, &flags_mask);
+
+  if (flags_mask == 1) {
+    flags_mask = PTE_D;
+  } else if (flags_mask == 2) {
+    flags_mask = PTE_A;
+  } else if (flags_mask == 3) {
+    flags_mask = PTE_D | PTE_A;
+  } else if (flags_mask != 0) {
+    return -1;
+  }
+
+  struct proc *p = myproc();
+  pagetable_t pagetable = p->pagetable;
+  printf("PAGETABLE %p\n", pagetable);
+
+  print_reqursive(pagetable, buf, buf + len, MAX_LEVEL, flags_mask);
+
+  return 0;
+}
+
+void reset_reqursive(pagetable_t pagetable, uint64 va, uint64 last_va,
+                     int level, int flags_mask) {
+  pte_t *pte = pagetable + PX(level, va);
+  for (; va < last_va && pte < pagetable + PTECOUNT; va += PAGESIZE(level), ++pte) {
+    
+    if (!(*pte & PTE_V)) {
+      continue;
+    }
+
+    if (level == 0) {
+      *pte &= ~((uint64)flags_mask);
+    }
+
+    if (level > 0) {
+      reset_reqursive((pagetable_t)PTE2PA(*pte), va, last_va, level - 1,
+                      flags_mask);
+    }
+  }
+}
+
+uint64 sys_pagereset(void) {
+  uint64 buf;
+  argaddr(0, &buf);
+  uint64 len;
+  argaddr(1, &len);
+
+  if (buf == 0 || len == 0) {
+    buf = 0;
+    len = MAXVA;
+  }
+
+  if (buf + len > MAXVA) {
+    return -1;
+  }
+
+  int flags_mask;
+  argint(2, &flags_mask);
+
+  if (flags_mask == 1) {
+    flags_mask = PTE_D;
+  } else if (flags_mask == 2) {
+    flags_mask = PTE_A;
+  } else if (flags_mask == 3) {
+    flags_mask = PTE_D | PTE_A;
+  } else {
+    return -1;
+  }
+
+  struct proc *p = myproc();
+  pagetable_t pagetable = p->pagetable;
+
+  reset_reqursive(pagetable, buf, buf + len, MAX_LEVEL, flags_mask);
+
+  return 0;
+}

--- a/kernel/types.h
+++ b/kernel/types.h
@@ -8,3 +8,5 @@ typedef unsigned int  uint32;
 typedef unsigned long uint64;
 
 typedef uint64 pde_t;
+
+enum pageflag { DIRTY_PAGE = 1, ACCESSED_PAGE = 2 };

--- a/user/pgtest.c
+++ b/user/pgtest.c
@@ -5,6 +5,23 @@ void print_separator(const char *message) {
   printf("\n\n----- %s -----\n", message);
 }
 
+void test_pagedump_flags() {
+  print_separator("Testing pagedump flags");
+  printf("\nDump all pages:\n");
+  pagedump(0, 0, 0);
+
+  printf("\nDump dirty pages:\n");
+  pagedump(0, 0, DIRTY_PAGE);
+
+  printf("\nDump accessed pages:\n");
+  pagedump(0, 0, ACCESSED_PAGE);
+
+  printf("\nDump dirty and accessed pages:\n");
+  pagedump(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
+
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);  // clear A/D bits after test
+}
+
 int global_var;
 void test_global_var() {
   print_separator("Testing Global Variable");
@@ -15,7 +32,7 @@ void test_global_var() {
   printf("\nAfter global variable access (write):\n");
   pagedump((const char *)&global_var, 1, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -24,7 +41,7 @@ void test_global_var() {
   pagedump((const char *)&global_var, 1, 0);
 
   global_var = x;      // on purpose to suppres unused variable warning
-  pagereset(0, 0, 3);  // clear A/D bits after test
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);  // clear A/D bits after test
 }
 
 void test_stack_var() {
@@ -40,7 +57,7 @@ void test_stack_var() {
   printf("\nAfter stack variable access (write):\n");
   pagedump((const char *)&stack_var, 1, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -48,7 +65,7 @@ void test_stack_var() {
   printf("\nAfter stack variable access (read):\n");
   pagedump((const char *)&stack_var, 1, 0);
 
-  pagereset(0, 0, 3);  // clear A/D bits after test
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);  // clear A/D bits after test
 }
 
 void test_stack_array() {
@@ -60,7 +77,7 @@ void test_stack_array() {
   printf("\nAfter allocation:\n");
   pagedump(0, 0, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -68,7 +85,7 @@ void test_stack_array() {
   printf("\nAfter stack array element access (write):\n");
   pagedump(stack_array, sizeof(stack_array), 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -76,7 +93,7 @@ void test_stack_array() {
   printf("\nAfter stack array element access (read):\n");
   pagedump(stack_array, sizeof(stack_array), 0);
 
-  pagereset(0, 0, 3);  // clear A/D bits after test
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);  // clear A/D bits after test
 }
 
 void test_heap_array() {
@@ -88,7 +105,7 @@ void test_heap_array() {
   printf("\nAfter allocation:\n");
   pagedump(0, 0, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -96,7 +113,7 @@ void test_heap_array() {
   printf("\nAfter heap array element access (write):\n");
   pagedump(heap_array, heap_array_size, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -104,7 +121,7 @@ void test_heap_array() {
   printf("\nAfter heap array element access (read):\n");
   pagedump(heap_array, heap_array_size, 0);
 
-  pagereset(0, 0, 3);
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);
   printf("\nAfter resetting A/D bits:\n");
   pagedump(0, 0, 0);
 
@@ -112,10 +129,11 @@ void test_heap_array() {
   printf("\nAfter deallocation:\n");
   pagedump(0, 0, 0);
 
-  pagereset(0, 0, 3);  // clear A/D bits after test
+  pagereset(0, 0, DIRTY_PAGE | ACCESSED_PAGE);  // clear A/D bits after test
 }
 
 int main() {
+  test_pagedump_flags();
   test_global_var();
   test_stack_var();
   test_stack_array();

--- a/user/pgtest.c
+++ b/user/pgtest.c
@@ -1,0 +1,108 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+void print_separator(const char *message) {
+  printf("\n\n----- %s -----\n", message);
+}
+
+int global_var;
+void test_global_var() {
+  print_separator("Testing Global Variable");
+  printf("\nInitial:\n");
+  pagedump(0, 0, 0);
+
+  global_var = 100;
+  printf("\nAfter global variable access (write):\n");
+  pagedump((const char *)&global_var, 1, 0);
+
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  int x = global_var;
+  printf("\nAfter global variable access (read):\n");
+  pagedump((const char *)&global_var, 1, 0);
+
+  global_var = x;      // on purpose to suppres unused variable warning
+  pagereset(0, 0, 3);  // clear A/D bits after test
+}
+
+void test_stack_var() {
+  print_separator("Testing Stack Variable");
+  printf("\nInitial:\n");
+  pagedump(0, 0, 0);
+
+  int stack_var;
+  printf("\nAfter allocating:\n");
+  pagedump(0, 0, 0);
+
+  stack_var = 100;
+  printf("\nAfter stack variable access (write):\n");
+  pagedump((const char *)&stack_var, 1, 0);
+
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  global_var = stack_var;
+  printf("\nAfter stack variable access (read):\n");
+  pagedump((const char *)&stack_var, 1, 0);
+
+  pagereset(0, 0, 3);  // clear A/D bits after test
+}
+
+void test_stack_array() {
+  print_separator("Testing Stack Array");
+  printf("\nInitial:\n");
+  pagedump(0, 0, 0);
+
+  char stack_array[2000];
+  printf("\nAfter allocation:\n");
+  pagedump(0, 0, 0);
+
+  stack_array[1] = 10;
+  printf("\nAfter stack array element access (write):\n");
+  pagedump(stack_array, sizeof(stack_array), 0);
+
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  global_var = stack_array[1999];
+  printf("\nAfter stack array element access (read):\n");
+  pagedump(stack_array, sizeof(stack_array), 0);
+
+  pagereset(0, 0, 3);  // clear A/D bits after test
+}
+
+void test_heap_array() {
+  print_separator("Testing Heap Array");
+  printf("\nInitial:\n");
+  pagedump(0, 0, 0);
+  uint64 heap_array_size = 4096 * 2.5;
+  char *heap_array = malloc(heap_array_size);
+  printf("\nAfter allocation:\n");
+  pagedump(0, 0, 0);
+
+  heap_array[1] = 10;
+  printf("\nAfter heap array element access (write):\n");
+  pagedump(heap_array, heap_array_size, 0);
+
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  global_var = heap_array[4096];
+  printf("\nAfter heap array element access (read):\n");
+  pagedump(heap_array, heap_array_size, 0);
+
+  pagereset(0, 0, 3);  // clear A/D bits after test
+}
+
+int main() {
+  test_global_var();
+  test_stack_var();
+  test_stack_array();
+  test_heap_array();
+  exit(0);
+}

--- a/user/pgtest.c
+++ b/user/pgtest.c
@@ -60,6 +60,10 @@ void test_stack_array() {
   printf("\nAfter allocation:\n");
   pagedump(0, 0, 0);
 
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
   stack_array[1] = 10;
   printf("\nAfter stack array element access (write):\n");
   pagedump(stack_array, sizeof(stack_array), 0);
@@ -84,7 +88,11 @@ void test_heap_array() {
   printf("\nAfter allocation:\n");
   pagedump(0, 0, 0);
 
-  heap_array[1] = 10;
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  heap_array[4096 * 2] = 10;
   printf("\nAfter heap array element access (write):\n");
   pagedump(heap_array, heap_array_size, 0);
 
@@ -95,6 +103,14 @@ void test_heap_array() {
   global_var = heap_array[4096];
   printf("\nAfter heap array element access (read):\n");
   pagedump(heap_array, heap_array_size, 0);
+
+  pagereset(0, 0, 3);
+  printf("\nAfter resetting A/D bits:\n");
+  pagedump(0, 0, 0);
+
+  free(heap_array);
+  printf("\nAfter deallocation:\n");
+  pagedump(0, 0, 0);
 
   pagereset(0, 0, 3);  // clear A/D bits after test
 }

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,8 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int pagedump(const char*, uint64, int);
+int pagereset(const char*, uint64, int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,5 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("pagedump");
+entry("pagereset");


### PR DESCRIPTION
Выполнены задания:
1 – реализован системный вызов `pagegdump`, выводящий страницы памяти, используемые процессом.  
2 – реализован системный вызов `pagereset`, сбрасывающий флаги `A` и   `D` у страниц памяти, используемых процессом.  
3 – написана тестовая утилита `pgtest`, тестирующая системные вызовы в разных сценариях (для переменной на стеке, глобальной переменной, массива на стеке и массива на куче).