### PR TITLE
Hw6: Character I/O devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+compile_commands.json
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/mem.o
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -139,6 +140,8 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_head\
+	$U/_hexdump\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ UPROGS=\
 	$U/_zombie\
 	$U/_head\
 	$U/_hexdump\
+	$U/_write\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -56,7 +56,7 @@ struct {
 // user write()s to the console go here.
 //
 int
-consolewrite(int user_src, uint64 src, int n)
+consolewrite(int user_src, uint64 src, int n, short minor)
 {
   int i;
 
@@ -77,7 +77,7 @@ consolewrite(int user_src, uint64 src, int n)
 // or kernel address.
 //
 int
-consoleread(int user_dst, uint64 dst, int n)
+consoleread(int user_dst, uint64 dst, int n, short minor)
 {
   uint target;
   int c;

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -70,6 +70,9 @@ void            log_write(struct buf*);
 void            begin_op(void);
 void            end_op(void);
 
+// mem.c
+void            meminit(void);
+
 // pipe.c
 int             pipealloc(struct file**, struct file**);
 void            pipeclose(struct pipe*, int);

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -116,7 +116,7 @@ fileread(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].read)
       return -1;
-    r = devsw[f->major].read(1, addr, n);
+    r = devsw[f->major].read(1, addr, n, f->minor);
   } else if(f->type == FD_INODE){
     ilock(f->ip);
     if((r = readi(f->ip, 1, addr, f->off, n)) > 0)
@@ -144,7 +144,7 @@ filewrite(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].write)
       return -1;
-    ret = devsw[f->major].write(1, addr, n);
+    ret = devsw[f->major].write(1, addr, n, f->minor);
   } else if(f->type == FD_INODE){
     // write a few blocks at a time to avoid exceeding
     // the maximum log transaction size, including

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -7,6 +7,7 @@ struct file {
   struct inode *ip;  // FD_INODE and FD_DEVICE
   uint off;          // FD_INODE
   short major;       // FD_DEVICE
+  short minor;       // FD_DEVICE
 };
 
 #define major(dev)  ((dev) >> 16 & 0xFFFF)
@@ -31,10 +32,16 @@ struct inode {
 
 // map major device number to device functions.
 struct devsw {
-  int (*read)(int, uint64, int);
-  int (*write)(int, uint64, int);
+  int (*read)(int, uint64, int, short);
+  int (*write)(int, uint64, int, short);
 };
 
 extern struct devsw devsw[];
 
 #define CONSOLE 1
+#define MEM 2
+
+#define DEV_NULL 0
+#define DEV_ZERO 1
+#define DEV_URANDOM 2
+#define DEV_NULLSTAT 3

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -207,7 +207,7 @@ ialloc(uint dev, short type)
     dip = (struct dinode*)bp->data + inum%IPB;
     if(dip->type == 0){  // a free inode
       memset(dip, 0, sizeof(*dip));
-      dip->type = type;
+        dip->type = type;
       log_write(bp);   // mark it allocated on the disk
       brelse(bp);
       return iget(dev, inum);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -12,6 +12,7 @@ main()
 {
   if(cpuid() == 0){
     consoleinit();
+    meminit();
     printfinit();
     printf("\n");
     printf("xv6 kernel is booting\n");

--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -1,0 +1,184 @@
+#include "types.h"
+#include "param.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "file.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "defs.h"
+#include "proc.h"
+
+static int
+nullwrite(int user_src, uint64 src, int n, short minor) {
+  if (n < 0) {
+    return -1;
+  }
+  return n;
+}
+
+static int
+nullread(int user_dst, uint64 dst, int n, short minor) {
+  if (n < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+
+static int
+zerowrite(int user_src, uint64 src, int n, short minor) {
+  return -1;
+}
+
+#define BUF_SIZE 1024
+
+static int
+zeroread(int user_dst, uint64 dst, int n, short minor) {
+  if (n < 0) {
+    return -1;
+  }
+  char buf[BUF_SIZE];
+  for (char *p = buf; p != buf + BUF_SIZE; ++p) {
+    *p = 0;
+  }
+  if (n < 0) {
+    return -1;
+  }
+
+  uint target = n;
+  while (n > 0) {
+    int len = BUF_SIZE;
+    if (len > n) {
+      len = n;
+    }
+
+    if (either_copyout(user_dst, dst, &buf, len) == -1) {
+      return -1;
+    }
+    n -= len;
+  }
+  return target - n;
+}
+
+static const uint64 a = 6364136223846793005;
+static const uint64 c = 1442695040888963407;
+static uint64 seed = 1234;
+static char urandom_buf[BUF_SIZE];
+static char *urandom_ptr = urandom_buf;
+static struct sleeplock urandom_lock;
+
+static void regenerate() {
+  for (uint64 *p = (uint64 *) urandom_buf; p != (uint64 *) (urandom_buf + BUF_SIZE); ++p) {
+    seed = a * seed + c;
+    *p = seed;
+  }
+  urandom_ptr = urandom_buf;
+}
+
+static int
+urandomwrite(int user_src, uint64 src, int n, short minor) {
+  if (n != sizeof(uint64)) {
+    return -1;
+  }
+  uint64 new_seed;
+  if (either_copyin(&new_seed, user_src, src, sizeof(uint64)) == -1) {
+    return 0;
+  }
+
+  acquiresleep(&urandom_lock);
+  seed = new_seed;
+  regenerate();
+  releasesleep(&urandom_lock);
+
+  return n;
+}
+
+static int
+urandomread(int user_dst, uint64 dst, int n, short minor) {
+  if (n < 0) {
+    return -1;
+  }
+
+  uint target = n;
+
+  acquiresleep(&urandom_lock);
+  while (n > 0) {
+    if (urandom_ptr == urandom_buf + BUF_SIZE) {
+      regenerate();
+    }
+    uint len = urandom_buf + BUF_SIZE - urandom_ptr;
+    if (len > n) {
+      len = n;
+    }
+
+    if (either_copyout(user_dst, dst, urandom_ptr, len) == -1) {
+      releasesleep(&urandom_lock);
+      return -1;
+    }
+    urandom_ptr += len;
+    n -= len;
+  }
+  releasesleep(&urandom_lock);
+
+  return target - n;
+}
+
+static uint64 bytes_read = 0;
+static struct sleeplock nullstat_lock;
+
+static int
+nullstatwrite(int user_src, uint64 src, int n, short minor) {
+  if (n < 0) {
+    return -1;
+  }
+
+  acquiresleep(&nullstat_lock);
+  bytes_read += n;
+  releasesleep(&nullstat_lock);
+
+  return n;
+}
+
+static int
+nullstatread(int user_dst, uint64 dst, int n, short minor) {
+  if (n != sizeof(uint64)) {
+    return -1;
+  }
+
+  acquiresleep(&nullstat_lock);
+  int result = n;
+  if (either_copyout(user_dst, dst, &bytes_read, sizeof(uint64)) == -1) {
+    result = 0;
+  }
+  releasesleep(&nullstat_lock);
+
+  return result;
+}
+
+static struct devsw devices[] = {
+  [DEV_NULL]{nullread, nullwrite},
+  [DEV_ZERO]{zeroread, zerowrite},
+  [DEV_URANDOM]{urandomread, urandomwrite},
+  [DEV_NULLSTAT]{nullstatread, nullstatwrite},
+};
+
+static int
+memwrite(int user_src, uint64 src, int n, short minor) {
+  return devices[minor].write(user_src, src, n, minor);
+}
+
+static int
+memread(int user_dst, uint64 dst, int n, short minor) {
+  return devices[minor].read(user_dst, dst, n, minor);
+}
+
+void
+meminit(void) {
+  initlock(&urandom_lock.lk, "urandom");
+  initlock(&nullstat_lock.lk, "nullstat");
+  regenerate();
+
+  devsw[MEM].read = memread;
+  devsw[MEM].write = memwrite;
+}

--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -32,16 +32,10 @@ zerowrite(int user_src, uint64 src, int n, short minor) {
 }
 
 #define BUF_SIZE 1024
+char buf[BUF_SIZE] = {0};
 
 static int
 zeroread(int user_dst, uint64 dst, int n, short minor) {
-  if (n < 0) {
-    return -1;
-  }
-  char buf[BUF_SIZE];
-  for (char *p = buf; p != buf + BUF_SIZE; ++p) {
-    *p = 0;
-  }
   if (n < 0) {
     return -1;
   }

--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -117,11 +117,11 @@ urandomread(int user_dst, uint64 dst, int n, short minor) {
       return -1;
     }
     urandom_ptr += len;
-    n -= len;
+    n -= (int) len;
   }
   releasesleep(&urandom_lock);
 
-  return target - n;
+  return (int) target - n;
 }
 
 static uint64 bytes_read = 0;
@@ -147,11 +147,13 @@ nullstatread(int user_dst, uint64 dst, int n, short minor) {
   }
 
   acquiresleep(&nullstat_lock);
+  uint64 bytes = bytes_read;
+  releasesleep(&nullstat_lock);
+
   int result = n;
-  if (either_copyout(user_dst, dst, &bytes_read, sizeof(uint64)) == -1) {
+  if (either_copyout(user_dst, dst, &bytes, sizeof(uint64)) == -1) {
     result = 0;
   }
-  releasesleep(&nullstat_lock);
 
   return result;
 }

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -352,6 +352,7 @@ sys_open(void)
   if(ip->type == T_DEVICE){
     f->type = FD_DEVICE;
     f->major = ip->major;
+    f->minor = ip->minor;
   } else {
     f->type = FD_INODE;
     f->off = 0;

--- a/user/head.c
+++ b/user/head.c
@@ -1,0 +1,74 @@
+#include "kernel/types.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define BUF_SIZE 512
+char buf[BUF_SIZE];
+
+int head(const int fd, int byte_limit) {
+  int read_result;
+  int to_read = ((byte_limit == -1) || (byte_limit >= BUF_SIZE)) ? BUF_SIZE : byte_limit;
+  while (to_read > 0 && (read_result = read(fd, buf, to_read)) != 0) {
+    if (read_result < 0) {
+      fprintf(2, "head: read error\n");
+      exit(1);
+    }
+    if (write(1, buf, read_result) != read_result) {
+      fprintf(2, "head: write error\n");
+      exit(1);
+    }
+    if (byte_limit != -1) {
+      byte_limit -= read_result;
+    }
+    to_read = byte_limit == -1 || byte_limit >= BUF_SIZE ? BUF_SIZE : byte_limit;
+  }
+  if (write(1, "\n", 1) != 1) {
+    fprintf(2, "head: write error\n");
+    exit(1);
+  }
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  int byte_limit = -1;
+  if (argc < 2) {
+    fprintf(2, "usage: head [-n number_of_bytes] [files]\n");
+  }
+
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-n") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(2, "head: -n requires an argument\n");
+        exit(1);
+      }
+
+      byte_limit = atoi(argv[i + 1]);
+      if (byte_limit < 0) {
+        fprintf(2, "head: -n argument must be non-negative number: %s\n", argv[i + 1]);
+        exit(1);
+      }
+      ++i;
+    }
+  }
+
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "-n") == 0) {
+      ++i;
+      continue;
+    }
+
+    int fd;
+    if ((fd = open(argv[i], O_RDONLY)) < 0) {
+      fprintf(2, "head: cannot open %s\n", argv[i]);
+      exit(1);
+    }
+
+    head(fd, byte_limit);
+    if (close(fd)) {
+      fprintf(2, "head: close error\n");
+      exit(1);
+    }
+  }
+
+  exit(0);
+}

--- a/user/hexdump.c
+++ b/user/hexdump.c
@@ -17,7 +17,8 @@ void print_hex_addr(uint addr) {
 }
 
 void print_word(uint16 x) {
-  char word[] = {digits[x >> 12 & 0xf], digits[x >> 8 & 0xf], digits[x >> 4 & 0xf], digits[x & 0xf], 0};
+  char word[] = {digits[x >> 12 & 0xf], digits[x >> 8 & 0xf],
+                 digits[x >> 4 & 0xf], digits[x & 0xf], 0};
   printf("%s ", word);
 }
 
@@ -44,7 +45,7 @@ int main(int argc, char *argv[]) {
     print_hex_addr(addr);
 
     for (i = 0; i + 2 <= n; i += 2) {
-      uint16 word = *(uint16 *) (buf + i);
+      uint16 word = *(uint16 *)(buf + i);
       print_word(word);
     }
 
@@ -55,9 +56,16 @@ int main(int argc, char *argv[]) {
     printf("\n");
     addr += n;
   }
+  if (n < 0) {
+    fprintf(2, "hexdump: failed to read from %s\n", argv[1]);
+    exit(1);
+  }
   print_hex_addr(addr);
   printf("\n");
 
-  close(fd);
+  if (close(fd)) {
+    fprintf(2, "hexdump: failed to close %s\n", argv[1]);
+    exit(1);
+  }
   exit(0);
 }

--- a/user/hexdump.c
+++ b/user/hexdump.c
@@ -1,0 +1,63 @@
+#include "kernel/types.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define BUF_SIZE 16
+
+static char digits[] = "0123456789abcdef";
+
+void print_hex_addr(uint addr) {
+  char line[8];
+  for (int i = 6; i >= 0; --i) {
+    line[i] = digits[addr & 0xf];
+    addr >>= 4;
+  }
+  line[7] = '\0';
+  printf("%s ", line);
+}
+
+void print_word(uint16 x) {
+  char word[] = {digits[x >> 12 & 0xf], digits[x >> 8 & 0xf], digits[x >> 4 & 0xf], digits[x & 0xf], 0};
+  printf("%s ", word);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc > 2) {
+    fprintf(2, "usage: hexdump [file]\n");
+    exit(1);
+  }
+
+  int fd = 0;
+  if (argc == 2) {
+    fd = open(argv[1], O_RDONLY);
+    if (fd < 0) {
+      fprintf(2, "hexdump: cannot open %s\n", argv[1]);
+      exit(1);
+    }
+  }
+
+  uchar buf[BUF_SIZE + 4];
+  uint addr = 0;
+  int n, i;
+
+  while ((n = read(fd, buf, BUF_SIZE)) > 0) {
+    print_hex_addr(addr);
+
+    for (i = 0; i + 2 <= n; i += 2) {
+      uint16 word = *(uint16 *) (buf + i);
+      print_word(word);
+    }
+
+    if (n % 2) {
+      uint16 word = buf[n - 1] & 0xff;
+      print_word(word);
+    }
+    printf("\n");
+    addr += n;
+  }
+  print_hex_addr(addr);
+  printf("\n");
+
+  close(fd);
+  exit(0);
+}

--- a/user/init.c
+++ b/user/init.c
@@ -16,6 +16,11 @@ main(void)
 {
   int pid, wpid;
 
+  mknod("null", MEM, DEV_NULL);
+  mknod("zero", MEM, DEV_ZERO);
+  mknod("urandom", MEM, DEV_URANDOM);
+  mknod("nullstat", MEM, DEV_NULLSTAT);
+
   if(open("console", O_RDWR) < 0){
     mknod("console", CONSOLE, 0);
     open("console", O_RDWR);

--- a/user/write.c
+++ b/user/write.c
@@ -1,0 +1,13 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[]) {
+  long len = strlen(argv[1]);
+  if (write(1, argv[1], (int) len) != len) {
+    fprintf(2, "write: write error\n");
+    exit(1);
+  }
+  exit(0);
+}


### PR DESCRIPTION
Реализован драйвер (`mem.c`), подерживающий символьные устройства `null`, `zero`, `urandom`, `nullstat`. В процессе была добавлена поддержка minor номеров устройств с возможностью использования в коде драйверов.
Добавлена инициализация устройств с реализованным драйвером.

Для тестирования создана утилита `head`, принимающая в качестве параметров имена файлов, которые она должна прочитать и вывести в консоль и число байт (флаг `-n`), которое она должна вывести.
Также была реализована утилита `hexdump`, принимающая в качестве аргументов файл (если файл не указан, чтение происходит из stdin) и выводящая его в шестнадцатеричной системе счисления с соответствующим форматированием.
Была написана утилита `write`, которая выводит в консоль свой первый аргумент, не добавляя никаких дополнительных символов и сообщая об ошибке в случае неудачи. 

Девайсы были протестированы командами (нужно учитывать, что `head` выводит в конце `\n`, а hexdump выводит байты в порядке little endian) :
#### `null`: 
```
$ write hello > null
$ head -n 10 null | hexdump
0000000 000a 
0000001 
```
#### `zero`:
```
$ write hello > zero
write: write error
$ head -n 10 zero | hexdump
0000000 0000 0000 0000 0000 0000 000a 
000000b
```
#### `urandom`:
```
$ head -n 5 urandom | hexdump
0000000 8839 2006 0ada 
0000006 
$ write hello > urandom
write: write error
$ write aaaaaaaa > urandom
$ head -n 5 urandom | hexdump
0000000 be5c de49 0a8f 
0000006
$ write aaaaaaaa > urandom
$ head -n 7 urandom | hexdump
0000000 be5c de49 118f 0aa9 
0000008 
```  
#### `nullstat`:
```
$ head -n 3 nullstat
head: read error
$ head -n 8 nullstat | hexdump
0000000 0000 0000 0000 0000 000a 
0000009 
$ write hello > nullstat
$ head -n 8 nullstat | hexdump
0000000 0005 0000 0000 0000 000a 
0000009 
$ write world! > nullstat
$  head -n 8 nullstat | hexdump
0000000 000b 0000 0000 0000 000a 
0000009 
```