### PR TITLE
Hw7: RTC (real time clock)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/rtc.o \
+  $K/sysrtc.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -139,6 +141,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_date\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)
@@ -163,10 +166,20 @@ ifndef CPUS
 CPUS := 3
 endif
 
+# RTC configuration
+# Options:
+#  - 'localtime': Use local time from the host
+#  - '2023-01-01T12:00:00': Use a specific date and time
+#  - 'utc': Use UTC time
+ifndef RTC
+RTC := localtime
+endif
+
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
 QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+QEMUOPTS += -rtc base=$(RTC),clock=host
 
 qemu: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -107,6 +107,9 @@ int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 
+// rtc.c
+uint64          rtcread(void);
+
 // swtch.S
 void            swtch(struct context*, struct context*);
 

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -108,6 +108,7 @@ int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 
 // rtc.c
+void            rtcinit(void);
 uint64          rtcread(void);
 
 // swtch.S

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -29,6 +29,7 @@ main()
     fileinit();      // file table
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process
+    rtcinit();      // first user process
     __sync_synchronize();
     started = 1;
   } else {

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -21,6 +21,10 @@
 #define UART0 0x10000000L
 #define UART0_IRQ 10
 
+// qemu puts RTC registers here in physical memory.
+#define RTC_LOW 0x101000
+#define RTC_HIGH 0x101004
+
 // virtio mmio interface
 #define VIRTIO0 0x10001000
 #define VIRTIO0_IRQ 1

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -3,10 +3,12 @@
 #include "riscv.h"
 #include "defs.h"
 
-#define RTCWord(word)
-#define ReadRTCLow (*((volatile uint32 *)(RTC_LOW)))
-#define ReadRTCHigh (*((volatile uint32 *)(RTC_HIGH)))
+#define ReadRTC(word) (*((volatile uint32 *)(word)))
 
 uint64 rtcread(void) {
-  return ((uint64)ReadRTCHigh << 32) + ReadRTCLow;
+  // read low register first
+  const uint32 low = ReadRTC(RTC_LOW);
+  const uint32 high = ReadRTC(RTC_HIGH);
+
+  return ((uint64)high << 32) | low;
 }

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -2,13 +2,21 @@
 #include "types.h"
 #include "riscv.h"
 #include "defs.h"
+#include "spinlock.h"
 
 #define ReadRTC(word) (*((volatile uint32 *)(word)))
 
+static struct spinlock lock;
+
+void rtcinit(void) {
+  initlock(&lock, "rtc");
+}
+
 uint64 rtcread(void) {
+  acquire(&lock);
   // read low register first
   const uint32 low = ReadRTC(RTC_LOW);
   const uint32 high = ReadRTC(RTC_HIGH);
-
+  release(&lock);
   return ((uint64)high << 32) | low;
 }

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -1,0 +1,12 @@
+#include "memlayout.h"
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+
+#define RTCWord(word)
+#define ReadRTCLow (*((volatile uint32 *)(RTC_LOW)))
+#define ReadRTCHigh (*((volatile uint32 *)(RTC_HIGH)))
+
+uint64 rtcread(void) {
+  return ((uint64)ReadRTCHigh << 32) + ReadRTCLow;
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_time(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_time]    sys_time,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_time   22

--- a/kernel/sysrtc.c
+++ b/kernel/sysrtc.c
@@ -1,0 +1,14 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "defs.h"
+
+uint64 sys_time(void) {
+  uint64 p;
+  argaddr(0, &p);
+  uint64 timestamp = rtcread();
+
+  return copyout(myproc()->pagetable, p, (char *) &timestamp, sizeof(timestamp));
+}

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -27,6 +27,9 @@ kvmmake(void)
   // uart registers
   kvmmap(kpgtbl, UART0, UART0, PGSIZE, PTE_R | PTE_W);
 
+  // rtc words
+  kvmmap(kpgtbl, RTC_LOW, RTC_LOW, PGSIZE, PTE_R);
+
   // virtio mmio disk interface
   kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
 

--- a/user/date.c
+++ b/user/date.c
@@ -1,0 +1,102 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "kernel/stat.h"
+
+typedef struct {
+  int year;
+  int month;
+  int day;
+  int day_of_week;
+  int hour;
+  int minute;
+  int second;
+  int millisecond;
+} DateTime;
+
+static const long long NANOS_PER_SECOND = 1000000000LL;
+static const long long SECONDS_PER_DAY = 1LL * 24 * 60 * 60;
+static const long long DAYS_FROM_0000_03_01_TO_1970_01_01 = 719468LL;
+static const long long DAYS_PER_400_YEARS = 1LL * 365 * 400 + 97;
+static const long long DAYS_PER_100_YEARS = 1LL * 365 * 100 + 24;
+static const long long DAYS_PER_4_YEARS = 1LL * 365 * 4 + 1;
+
+static DateTime timestamp_to_datetime(long long nanoseconds_since_epoch) {
+  DateTime dt;
+
+  long long seconds_since_epoch = nanoseconds_since_epoch / NANOS_PER_SECOND;
+  int nanos_within_second = (int) (nanoseconds_since_epoch % NANOS_PER_SECOND);
+
+  if (nanos_within_second < 0) {
+    nanos_within_second += (int) NANOS_PER_SECOND;
+    seconds_since_epoch -= 1;
+  }
+  dt.millisecond = nanos_within_second / 1000000;
+
+  long long total_days = seconds_since_epoch / SECONDS_PER_DAY;
+  int seconds_within_day = (int) (seconds_since_epoch % SECONDS_PER_DAY);
+
+  if (seconds_within_day < 0) {
+    seconds_within_day += (int) SECONDS_PER_DAY;
+    total_days -= 1;
+  }
+
+  dt.hour = seconds_within_day / 3600;
+  dt.minute = (seconds_within_day % 3600) / 60;
+  dt.second = seconds_within_day % 60;
+
+  // These weird formulas are taken from this article: https://howardhinnant.github.io/date_algorithms.html
+  long long days_from_0000_03_01 = total_days + DAYS_FROM_0000_03_01_TO_1970_01_01;
+  const long long era = (days_from_0000_03_01 >= 0
+                           ? days_from_0000_03_01
+                           : days_from_0000_03_01 - (DAYS_PER_400_YEARS - 1)) / DAYS_PER_400_YEARS;
+  const uint32 doe = (uint32)(days_from_0000_03_01 - era * DAYS_PER_400_YEARS);
+  const uint32 yoe = (doe - doe / DAYS_PER_4_YEARS + doe / DAYS_PER_100_YEARS - doe / (DAYS_PER_400_YEARS - 1)) / 365;
+  const int y = (int) (yoe) + (int) (era * 400);
+  const uint32 doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+  const uint32 mp = (5 * doy + 2) / 153;
+  const uint32 d = doy - (153 * mp + 2) / 5 + 1;
+  const uint32 m = mp + (mp < 10 ? 3 : -9);
+
+  dt.year = y + (m <= 2);
+  dt.month = (int) m;
+  dt.day = (int) d;
+
+  dt.day_of_week = (int) ((total_days % 7 + 3 + 7) % 7 + 1);
+
+  return dt;
+}
+
+static const char *days[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+static const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+static void itoa_n(int num, const uint32 n, char *buf) {
+  for (int i = n - 1; i >= 0; --i) {
+    buf[i] = num % 10 + '0';
+    num /= 10;
+  }
+  buf[n] = '\0';
+}
+
+static void print_time(const DateTime *rt) {
+  char hour[3], minute[3], second[3], millisecond[4];
+  itoa_n(rt->hour, 2, hour);
+  itoa_n(rt->minute, 2, minute);
+  itoa_n(rt->second, 2, second);
+  itoa_n(rt->millisecond, 3, millisecond);
+  printf("%s %d %s %d %s:%s:%s.%s\n",
+         days[rt->day_of_week - 1], rt->day,
+         months[rt->month - 1],
+         rt->year,
+         hour, minute, second, millisecond);
+}
+
+int main() {
+  uint64 timestamp;
+  if (time(&timestamp) == -1) {
+    fprintf(2, "date: failed to get timestamp\n");
+    return -1;
+  }
+  DateTime date_time = timestamp_to_datetime(timestamp);
+  print_time(&date_time);
+  return 0;
+}

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int time(void*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("time");


### PR DESCRIPTION
Разработан системный вызов `time`, принимающий указатель на 64-битное знаковое число и кладущий по этому адресу timestamp, измеряемый в наносекундах прошедших с начала эпохи UNIX.

Реализована утилита `date`, выводящая дату и время в человекочитаемом формате в консоль.

Поддержан аргумент командной строки, позволяющий при сборке и запуске задать системное время в `qemu`:
`make qemu RTC=2025-01-31T12:00:00` 